### PR TITLE
🐛 Fix zlib.gzip to zlib.gzipSync

### DIFF
--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -128,11 +128,10 @@ export class UsersRepository {
 
     const file = (await this.firestoreStorage).bucket().file('positives.json.gz')
     const json = JSON.stringify({ data: [].concat(...tempIDs) })
+    const gzip = zlib.gzipSync(json)
 
-    zlib.gzip(json, async (error, buffer) => {
-      await file.save(buffer)
-      await file.setMetadata({ contentType: 'application/gzip' })
-    })
+    await file.save(gzip)
+    await file.setMetadata({ contentType: 'application/gzip' })
 
     return
   }


### PR DESCRIPTION
### Overview
- It was working in the local environment, but not in the Lambda environment.
  - This is probably due to processing by threadpool.
  - https://nodejs.org/api/zlib.html#zlib_threadpool_usage_and_performance_considerations