### PR TITLE
Add normal user org validation JWT guard

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { SharedModule } from '../shared/shared.module'
 import { FirebaseAdminUserLoginStrategy } from './strategies/firebase-admin-user-login.strategy'
 import { FirebaseAdminUserValidateStrategy } from './strategies/firebase-admin-user-validate.strategy'
 import { AdminsModule } from '../admins/admins.module'
+import { FirebaseNormalUserOrgValidateStrategy } from './strategies/firebase-normal-user-org-validate.strategy'
 
 @Module({
   imports: [AdminsModule, UsersModule, SharedModule],
@@ -15,6 +16,7 @@ import { AdminsModule } from '../admins/admins.module'
     AuthService,
     FirebaseNormalUserLoginStrategy,
     FirebaseNormalUserValidateStrategy,
+    FirebaseNormalUserOrgValidateStrategy,
     FirebaseAdminUserLoginStrategy,
     FirebaseAdminUserValidateStrategy,
   ],

--- a/src/auth/guards/firebase-normal-user-org-validate.guard.ts
+++ b/src/auth/guards/firebase-normal-user-org-validate.guard.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+
+@Injectable()
+export class FirebaseNormalUserOrgValidateGuard extends AuthGuard(
+  'firebase-normal-user-org-validate'
+) {}

--- a/src/auth/strategies/firebase-normal-user-org-validate.strategy.ts
+++ b/src/auth/strategies/firebase-normal-user-org-validate.strategy.ts
@@ -1,0 +1,38 @@
+import { Strategy, VerifiedCallback } from 'passport-custom'
+import { PassportStrategy } from '@nestjs/passport'
+import { Injectable, UnauthorizedException } from '@nestjs/common'
+import { ExtractJwt } from 'passport-jwt'
+import { Request } from 'express'
+import * as firebaseAdmin from 'firebase-admin'
+import { validateNormalTokenAnonymousPayload } from '../util'
+
+@Injectable()
+export class FirebaseNormalUserOrgValidateStrategy extends PassportStrategy(
+  Strategy,
+  'firebase-normal-user-org-validate'
+) {
+  async validate(req: Request, done: VerifiedCallback): Promise<any> {
+    const extractorFunction = ExtractJwt.fromAuthHeaderAsBearerToken()
+    const token = extractorFunction(req)
+    if (!token) {
+      throw new UnauthorizedException('No bearer token found in the header')
+    }
+
+    let userDecodedToken: firebaseAdmin.auth.DecodedIdToken
+    try {
+      userDecodedToken = await firebaseAdmin.auth().verifyIdToken(token)
+    } catch (error) {
+      throw new UnauthorizedException(error.message)
+    }
+
+    // Expect all normal access tokens (FDT) to have provider id anonymous data.
+    validateNormalTokenAnonymousPayload(userDecodedToken)
+
+    // Check organizationCode custom claim.
+    if (!userDecodedToken.organizationCode) {
+      throw new UnauthorizedException('Access token does not contain custom claim organizationCode')
+    }
+
+    done(null, userDecodedToken)
+  }
+}


### PR DESCRIPTION
### Changes:
- Add normal user org validation guard.
    - Checks for `organizationCode` custom claim on `JWT`.
    - Can be used on specific routes with `@UseGuards(FirebaseNormalUserOrgValidateGuard)` decorator.

We can use this for all endpoints which need the `organizationCode` custom claim to be present.