### PR TITLE
Admins - Add ACL support

### DIFF
--- a/src/admins/admins.repository.ts
+++ b/src/admins/admins.repository.ts
@@ -52,6 +52,7 @@ export class AdminsRepository {
             addedByAdminUserId: doc.data().addedByAdminUserId,
             addedByAdminEmail: doc.data().addedByAdminEmail,
             createdAt: doc.data().createdAt,
+            accessControlList: doc.data().accessControlList,
           }
         })
       })
@@ -86,6 +87,7 @@ export class AdminsRepository {
             addedByAdminUserId: doc.data().addedByAdminUserId,
             addedByAdminEmail: doc.data().addedByAdminEmail,
             createdAt: doc.data().createdAt,
+            accessControlList: doc.data().accessControlList,
           }
           adminsArray.push(adminEach)
         })

--- a/src/admins/admins.service.ts
+++ b/src/admins/admins.service.ts
@@ -17,6 +17,7 @@ import {
   canUserCreateNationalAdmin,
   canUserCreatePrefectureAdmin,
   getPrefectureAdminACLKey,
+  getNationalAdminACLKey,
 } from '../shared/acl'
 import { RequestAdminUser } from '../shared/interfaces'
 import { OrganizationsService } from '../organizations/organizations.service'
@@ -46,7 +47,7 @@ export class AdminsService {
     createAdminDto.addedByAdminUserId = requestAdminUser.uid
     createAdminDto.addedByAdminEmail = requestAdminUser.email
     createAdminDto.userAdminRole = createAdminRequest.adminRole
-
+    createAdminDto.accessControlList = [getSuperAdminACLKey()]
     // Check if the user has access to create new user with desired adminRole in the payload.
     // Also, determine what accessKey will be added to the new created admin.
     switch (createAdminRequest.adminRole) {
@@ -55,6 +56,8 @@ export class AdminsService {
           throw new UnauthorizedException('Insufficient access to create this adminRole')
         }
         createAdminDto.userAccessKey = getSuperAdminACLKey()
+        // No need to add any ACL Key in accessControlList, since it already contains the
+        // superAdmin key added above.
         break
 
       case AdminRole.nationalAdminRole:
@@ -82,6 +85,11 @@ export class AdminsService {
 
         createAdminDto.userAccessKey = getPrefectureAdminACLKey(createAdminRequest.prefectureId)
         createAdminDto.prefectureId = createAdminRequest.prefectureId
+        createAdminDto.accessControlList.push(
+          getNationalAdminACLKey(),
+          getPrefectureAdminACLKey(createAdminRequest.prefectureId)
+        )
+
         break
 
       case AdminRole.organizationAdminRole:
@@ -103,6 +111,11 @@ export class AdminsService {
 
         createAdminDto.userAccessKey = getOrganizationAdminACLKey(createAdminRequest.organizationId)
         createAdminDto.organizationId = createAdminRequest.organizationId
+        createAdminDto.accessControlList.push(
+          getNationalAdminACLKey(),
+          getOrganizationAdminACLKey(createAdminRequest.organizationId)
+        )
+
         break
 
       default:

--- a/src/admins/classes/admin.class.ts
+++ b/src/admins/classes/admin.class.ts
@@ -2,7 +2,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
 import { Moment } from 'moment-timezone'
 import { ResourceWithACL, AdminRole } from '../../shared/acl'
 
-export class Admin {
+export class Admin extends ResourceWithACL {
   @ApiProperty()
   adminUserId: string
 

--- a/src/admins/dto/create-admin.dto.ts
+++ b/src/admins/dto/create-admin.dto.ts
@@ -1,53 +1,16 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
 import { IsString, IsNotEmpty, IsEnum, IsEmail, ValidateIf, Min, IsInt, Max } from 'class-validator'
-import { AdminRole } from '../../shared/acl'
+import { AdminRole, ResourceWithACL } from '../../shared/acl'
 
-export class CreateAdminDto {
-  @ApiProperty()
-  @IsString()
-  @IsNotEmpty()
+export class CreateAdminDto extends ResourceWithACL {
+  // Keys without any decorators are non-Whitelisted. Validator will throw error if it's passed in payload.
   adminUserId: string
-
-  @ApiProperty({ enum: AdminRole })
-  @IsNotEmpty()
-  @IsEnum(AdminRole)
   userAdminRole: AdminRole
-
-  @ApiProperty()
-  @IsString()
-  @IsNotEmpty()
   userAccessKey: string
-
-  @ApiPropertyOptional({
-    description: 'Optional, needed when admin role is ORGANIZATION_ADMIN_ROLE',
-  })
-  @ValidateIf((o) => o.userAdminRole === AdminRole.organizationAdminRole)
-  @IsString()
-  @IsNotEmpty()
   organizationId: string
-
-  @ApiPropertyOptional({
-    description: 'Optional, needed when admin role is PREFECTURE_ADMIN_ROLE',
-  })
-  @ValidateIf((o) => o.userAdminRole === AdminRole.prefectureAdminRole)
-  @IsInt()
-  @Min(0)
-  @Max(47)
   prefectureId: number
-
-  @ApiProperty()
-  @IsString()
-  @IsNotEmpty()
   email: string
-
-  @ApiProperty()
-  @IsString()
-  @IsNotEmpty()
   addedByAdminUserId: string
-
-  @ApiProperty()
-  @IsString()
-  @IsNotEmpty()
   addedByAdminEmail: string
 }
 


### PR DESCRIPTION
### Changes:
- Add `access control` support to `admins` collection.
    - This will allow us to add filters like: 
      - `orgAdmins` can see admins belonging to their own org.
      - `orgAdmins` cannot delete other admins, except their own org, etc.