### PR TITLE
📛 Rename まもりあいJAPAN to まもりあいJapan

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2020, まもりあいJAPAN
+Copyright (c) 2020, まもりあいJapan
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Version](https://badgen.net/github/release/mamori-i-japan/mamori-i-japan-api)](https://github.com/mamori-i-japan/mamori-i-japan-api/releases)
 [![License](https://badgen.net/github/license/mamori-i-japan/mamori-i-japan-api)](./LICENSE)
 
-REST API Server for Japanese Exposure Notification App to fight against COVID-19 a.k.a. \"まもりあいJAPAN\".
+REST API Server for Japanese Exposure Notification App to fight against COVID-19 a.k.a. \"まもりあいJapan\".
 
 ## Architecture
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "mamori-i-japan-api",
   "version": "0.1.0",
-  "description": "REST API Server for Japanese Exposure Notification App to fight against COVID-19 a.k.a. \"まもりあいJAPAN\".",
+  "description": "REST API Server for Japanese Exposure Notification App to fight against COVID-19 a.k.a. \"まもりあいJapan\".",
   "author": {
-    "name": "まもりあいJAPAN",
+    "name": "まもりあいJapan",
     "url": "https://github.com/mamori-i-japan"
   },
   "contributors": [


### PR DESCRIPTION
### Overview
- SSIA 📛