### PR TITLE
[fix]`package-lock.json` version is old

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mamori-i-japan-api",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Now, I'm trying to execute this project.
Then, when I executed `npm install`, `package-lock.json` version was changed.

In `package.json`  the version is `0.1.0`,  so I found this change is appropriate.
https://github.com/mamori-i-japan/mamori-i-japan-api/blob/0f2999b451a59fb59c59a1ea047e8c0b192b04e0/package.json#L3

This is a first time pull request to this project, so please tell me if the contributing method is wrong.